### PR TITLE
Fix indexers query to include all indexers

### DIFF
--- a/.config.json
+++ b/.config.json
@@ -1,1 +1,1 @@
-[{"query": "{ indexers { id queryFeesCollected queryFeeRebates} }", "URL": "https://gateway-testnet.thegraph.com/network"}]
+[{"query": "{ indexers (first:1000) { id queryFeesCollected queryFeeRebates} }", "URL": "https://gateway-testnet.thegraph.com/network"}]


### PR DESCRIPTION
Default size of a query is 100 (we currently have more than 200 validators)